### PR TITLE
Name&search

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,6 +3,14 @@ class SearchesController < ApplicationController
   def index
     @products = Product.search(params[:search]).limit(10)
     @search = params[:search]
+    if user_signed_in?
+      @shops = Shop.all
+      rooms = current_user.rooms
+      #自分が入ってるroomの相手のidを格納する
+      @shop_ids = []
+      rooms.each do |r|
+        @shop_ids << r.shop_id
+      end
+    end
   end
-  
 end

--- a/app/views/rooms/show.html.haml
+++ b/app/views/rooms/show.html.haml
@@ -10,13 +10,11 @@
         .topheader__left--chat
 
         .topheader__right
-          ショップ名
+          = @shop.name
           .topheader__right--user
             
             
     .main
-      %h3 
-        - @shop.name
       .chat-field
         - @shops = Shop.all
         - @messages.each do |m|
@@ -46,12 +44,10 @@
         .topheader__left--chat
           
         .topheader__right
-          ユーザー名
+          = @user.username
           .topheader__right--user
 
     .main
-      %h3
-        - @user.username
       .chat-field
         - @messages.each do |m|
           / メッセージがUserによるものだったら

--- a/app/views/searches/index.html.haml
+++ b/app/views/searches/index.html.haml
@@ -30,20 +30,34 @@
                   の検索結果
               .search-result-number
                 ="1-#{@products.count}件表示"
-              .search-result-content
-              - @products.each do |product|
-                .product
-                  =link_to room_path(3) do
-                    .product__image
-                      = image_tag product.image.url, class: "figure"
-                    .product__content
-                      .product__content__name
-                        = product.name
-                      %ul.price
-                        %li 
-                          ￥
-                          = product.price
-                          (税込)
-                        %li
+                .search-result-content
+                - @products.each do |product|
+                  .product
+                    - if @shop_ids.include?(product.shop.id)
+                      =link_to room_path(current_user.rooms.find_by(shop_id: @shops.ids)) do
+                        .product__image
+                          = image_tag product.image.url, class: "figure"
+                        .product__content
+                          .product__content__name
+                            = product.name
+                          %ul.price
+                            %li 
+                              ￥
+                              = product.price
+                              (税込)
+                            %li
+                    - else
+                      =link_to "#" do
+                        .product__image
+                          = image_tag product.image.url, class: "figure"
+                        .product__content
+                          .product__content__name
+                            = product.name
+                          %ul.price
+                            %li 
+                              ￥
+                              = product.price
+                              (税込)
+                            %li
 
-          
+              

--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -25,7 +25,6 @@
             %img{src: "shop1.png",height:"16%",width:"88%"}
             %li
             = shop.name
-            %br
             %li
             = shop.genre
             / もしチャットルームがあったらそのチャットページへ。なければ新たなチャットルームを作成
@@ -63,14 +62,11 @@
             %img{src: "user1.png",height:"16%",width:"88%"}
             %li
             = user.username
-            %br
             %li
             = user.profile
             / もしチャットルームがあったらそのチャットページへ。なければ新たなチャットルームを作成/
             - if @user_ids.include?(user.id)
-              %br/
               = link_to "Chat", room_path(current_shop.rooms.find_by(user_id: user.id))
-              %br/
             - else
               = form_for Room.new do |f|
                 = f.hidden_field :user_id, :value => user.id


### PR DESCRIPTION
# What
チャットルームに相手の名前を表示する
ユーザーが商品検索した際に、商品をクリックするとショップ側のチャットページに飛ぶ

# Why
ユーザビリティを上げるため