### PR TITLE
商品登録　バリデーション

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,7 @@
 class Product < ActiveRecord::Base
   mount_uploader :image, ImageUploader
   belongs_to :shop
+  validates :name, :price,:image , presence: true
   def self.search(search) #self.でクラスメソッドとしている
     if search # Controllerから渡されたパラメータが!= nilの場合は、titleカラムを部分一致検索
       Product.where(['name LIKE ?', "%#{search}%"])


### PR DESCRIPTION
# What 
商品登録を空の値がある状態で登録しようとする場合、アラートが出るようにする

# Why
 エラーが表示されたため
 不十分なデータとして登録されないために